### PR TITLE
Allocate all GPU resources POC

### DIFF
--- a/gke/zonal/main.tf
+++ b/gke/zonal/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  # required_version = "~> 1.1.0"
 
   required_providers {
     google = {
@@ -110,7 +110,122 @@ provider "kubernetes" {
 }
 
 locals {
-  gpu_sizes = var.enable_gpu ? [
+  # TODO: move to a shared location
+  available_gpu_in_zones = {
+    "asia-east1-a":              ["t4", "p100", "k80"],
+		"asia-east1-b":              ["k80"],
+		"asia-east1-c":              ["t4", "v100", "p100"],
+		"asia-east2-a":              ["t4"],
+		"asia-east2-b":              [],
+		"asia-east2-c":              ["t4"],
+		"asia-northeast1-a":         ["a100", "t4"],
+		"asia-northeast1-b":         [],
+		"asia-northeast1-c":         ["a100", "t4"],
+		"asia-northeast2-a":         [],
+		"asia-northeast2-b":         [],
+		"asia-northeast2-c":         [],
+		"asia-northeast3-a":         ["a100"],
+		"asia-northeast3-b":         ["a100", "t4"],
+		"asia-northeast3-c":         ["t4"],
+		"asia-south1-a":             ["t4"],
+		"asia-south1-b":             ["t4"],
+		"asia-south1-c":             [],
+		"asia-southeast1-a":         ["t4"],
+		"asia-southeast1-b":         ["a100", "l4", "t4", "p4"],
+		"asia-southeast1-c":         ["a100", "t4", "p4"],
+		"asia-southeast2-a":         ["t4"],
+		"asia-southeast2-b":         ["t4"],
+		"asia-southeast2-c":         [],
+		"australia-southeast1-a":    ["t4", "p4"],
+		"australia-southeast1-b":    ["p4"],
+		"australia-southeast1-c":    ["t4", "p100"],
+		"europe-central2-a":         [],
+		"europe-central2-b":         ["t4"],
+		"europe-central2-c":         ["t4"],
+		"europe-north1-a":           [],
+		"europe-north1-b":           [],
+		"europe-north1-c":           [],
+		"europe-southwest1-a":       [],
+		"europe-southwest1-b":       [],
+		"europe-southwest1-c":       [],
+		"europe-west1-b":            ["p100", "k80", "t4"],
+		"europe-west1-c":            ["t4"],
+		"europe-west1-d":            ["p100", "k80", "t4"],
+		"europe-west12-a":           [],
+		"europe-west12-b":           [],
+		"europe-west12-c":           [],
+		"europe-west2-a":            ["t4"],
+		"europe-west2-b":            ["t4"],
+		"europe-west2-c":            [],
+		"europe-west3-a":            [],
+		"europe-west3-b":            ["t4"],
+		"europe-west3-c":            [],
+		"europe-west4-a":            ["a100", "l4", "t4", "v100", "p100"],
+		"europe-west4-b":            ["a100", "l4", "t4", "p4", "v100"],
+		"europe-west4-c":            ["l4", "t4", "p4", "v100"],
+		"europe-west6-a":            [],
+		"europe-west6-b":            [],
+		"europe-west6-c":            [],
+		"europe-west8-a":            [],
+		"europe-west8-b":            [],
+		"europe-west8-c":            [],
+		"europe-west9-a":            [],
+		"europe-west9-b":            [],
+		"europe-west9-c":            [],
+		"me-central1-a":             [],
+		"me-central1-b":             [],
+		"me-central1-c":             [],
+		"me-west1-a":                [],
+		"me-west1-b":                ["t4"],
+		"me-west1-c":                ["t4"],
+		"northamerica-northeast1-a": ["p4"],
+		"northamerica-northeast1-b": ["p4"],
+		"northamerica-northeast1-c": ["t4", "p4"],
+		"southamerica-east1-a":      [],
+		"southamerica-east1-b":      ["t4"],
+		"southamerica-east1-c":      ["t4"],
+		"us-central1-a":             ["a100", "l4", "t4", "p4", "v100", "k80"],
+		"us-central1-b":             ["a100", "l4", "t4", "v100"],
+		"us-central1-c":             ["a100", "t4", "p4", "v100", "p100", "k80"],
+		"us-central1-f":             ["a100", "t4", "v100", "p100"],
+		"us-east1-b":                ["a100", "l4", "p100"],
+		"us-east1-c":                ["t4", "v100", "p100", "k80"],
+		"us-east1-d":                ["l4", "t4", "k80"],
+		"us-east4-a":                ["l4", "t4", "p4"],
+		"us-east4-b":                ["t4", "p4"],
+		"us-east4-c":                ["a100", "t4", "p4"],
+		"us-east5-a":                [],
+		"us-east5-b":                [],
+		"us-east5-c":                [],
+		"us-south1-a":               [],
+		"us-south1-b":               [],
+		"us-south1-c":               [],
+		"us-west1-a":                ["l4", "t4", "v100", "p100"],
+		"us-west1-b":                ["a100", "l4", "t4", "v100", "p100", "k80"],
+		"us-west1-c":                [],
+		"us-west2-a":                [],
+		"us-west2-b":                ["p4", "t4"],
+		"us-west2-c":                ["p4", "t4"],
+		"us-west3-a":                [],
+		"us-west3-b":                [],
+		"us-west3-c":                [],
+		"us-west4-a":                ["t4"],
+		"us-west4-b":                ["a100", "t4"],
+		"us-west4-c":                [],
+  }
+
+  reserved_gpu_types = ["a100", "l4"]
+  accelerator_types = {
+    "t4": "nvidia-tesla-t4",
+    "v100": "nvidia-tesla-v100",
+    "p100": "nvidia-tesla-p100",
+    "p4": "nvidia-tesla-p4",
+    "k80": "nvidia-tesla-k80",
+    "a100": "nvidia-tesla-a100",
+    "l4": "nvidia-l4",
+  }
+
+  generic_gpu_instance_sizes = [
     "n1-standard-1",
     "n1-standard-2",
     "n1-standard-4",
@@ -118,21 +233,24 @@ locals {
     "n1-highmem-2",
     "n1-highmem-4",
     "n1-highmem-8",
-  ] : []
-  v100_sizes = var.enable_gpu ? [
-    "n1-standard-1",
-    "n1-standard-2",
-    "n1-standard-4",
-    "n1-standard-8",
-    "n1-highmem-2",
-    "n1-highmem-4",
-    "n1-highmem-8",
-  ] : []
-  a100_sizes = var.enable_a100 ? [
-    "a2-highgpu-1g",
-    "a2-highgpu-2g",
-    "a2-highgpu-4g",
-  ] : []
+  ]
+
+  reserved_sizes = {
+    "a100" = var.enable_a100 ? [
+      "a2-highgpu-1g",
+      "a2-highgpu-2g",
+      "a2-highgpu-4g",
+    ] : [],
+    "l4" = var.enable_l4 ? [
+      "g2-standard-4",
+      "g2-standard-8",
+      "g2-standard-12",
+    ] : [],
+  }
+
+  gpu_instances = {for gpu in local.available_gpu_in_zones[var.zone] : "${gpu}" => 
+    can(local.reserved_sizes[gpu]) ? local.reserved_sizes[gpu] : local.generic_gpu_instance_sizes
+  }
 }
 
 module "gke" {
@@ -221,8 +339,9 @@ module "gke" {
       preemptible               = false
       initial_node_count        = 0
     }
-    ], [for size in local.gpu_sizes : {
-      name                      = "${size}-nvidia-t4"
+    ], flatten([for gpu, sizes in local.gpu_instances : 
+      [for size in sizes: {
+      name                      = "${size}-nvidia-${gpu}"
       machine_type              = size
       node_locations            = var.zone
       min_count                 = 0
@@ -230,7 +349,9 @@ module "gke" {
       local_ssd_count           = 0
       local_ssd_ephemeral_count = 0
       accelerator_count         = 1
-      accelerator_type          = "nvidia-tesla-t4"
+      # accelerator_type is actually need for a100 & l4 as well
+      # https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
+      accelerator_type          = local.accelerator_types[gpu]
       disk_size_gb              = 200
       disk_type                 = "pd-standard"
       image_type                = "COS_CONTAINERD"
@@ -238,41 +359,8 @@ module "gke" {
       auto_upgrade              = true
       preemptible               = false
       initial_node_count        = 0
-    }],
-    [for size in local.v100_sizes : {
-      name                      = "${size}-nvidia-v100"
-      machine_type              = size
-      node_locations            = var.zone
-      min_count                 = 0
-      max_count                 = 20
-      local_ssd_count           = 0
-      local_ssd_ephemeral_count = 0
-      accelerator_count         = 1
-      accelerator_type          = "nvidia-tesla-v100"
-      disk_size_gb              = 200
-      disk_type                 = "pd-standard"
-      image_type                = "COS_CONTAINERD"
-      auto_repair               = true
-      auto_upgrade              = true
-      preemptible               = false
-      initial_node_count        = 0
-    }],
-    [for size in local.a100_sizes : {
-      name                      = "${size}-nvidia-a100"
-      machine_type              = size
-      node_locations            = var.zone
-      min_count                 = 0
-      max_count                 = 20
-      local_ssd_count           = 0
-      local_ssd_ephemeral_count = 0
-      disk_size_gb              = 200
-      disk_type                 = "pd-standard"
-      image_type                = "COS_CONTAINERD"
-      auto_repair               = true
-      auto_upgrade              = true
-      preemptible               = false
-      initial_node_count        = 0
-    }]
+    }]]),
+
   )
 
   node_pools_oauth_scopes = {
@@ -303,20 +391,12 @@ module "gke" {
       "zeet.co/dedicated" = "dedicated"
     }
 
-    }, {
-    for size in local.gpu_sizes : "${size}-nvidia-t4" => {
+    }, flatten([
+    for gpu, sizes in local.gpu_instances:
+      {for size in sizes : "${size}-nvidia-${gpu}" => {
       "zeet.co/dedicated"                = "dedicated"
-      "cloud.google.com/gke-accelerator" = "nvidia-tesla-t4"
-    } }, {
-    for size in local.v100_sizes : "${size}-nvidia-v100" => {
-      "zeet.co/dedicated"                = "dedicated"
-      "cloud.google.com/gke-accelerator" = "nvidia-tesla-v100"
-    } }, {
-    for size in local.a100_sizes : "${size}-nvidia-a100" => {
-      "zeet.co/dedicated"                = "dedicated"
-      "cloud.google.com/gke-accelerator" = "nvidia-tesla-a100"
-    }
-    }
+      "cloud.google.com/gke-accelerator" = local.accelerator_types[gpu]
+    }}])...
   )
 
 

--- a/gke/zonal/variables.tf
+++ b/gke/zonal/variables.tf
@@ -28,15 +28,17 @@ variable "user_id" {
   type = string
 }
 
-variable "enable_gpu" {
-  type = bool
-}
-
 variable "enable_tpu" {
   type = bool
 }
 
+# the following two variables determins whether to turn on gpu support if the zone has them
 variable "enable_a100" {
+  type    = bool
+  default = false
+}
+
+variable "enable_l4" {
   type    = bool
   default = false
 }


### PR DESCRIPTION
```
$ terraform plan -var project_id="zeet-demo" -var region="us-west1" -var zone="us-west1-b" -var cluster_id="zeet-zeet-example-gcp" -var cluster_name="zeet-zeet-example-gcp" -var cluster_domain="random.app" -var user_id="random" -var enable_l4="true" -var enable_tpu="true" -var enable_a100="true" -no-color > out

>>>

  # module.gke.google_container_node_pool.pools["n1-standard-4-nvidia-v100"] will be created
  + resource "google_container_node_pool" "pools" {
      + cluster                     = "zeet-zeet-zeet-example-gcp"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "n1-standard-4-nvidia-v100"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = [
          + "us-west1-b",
        ]
      + operation                   = (known after apply)
      + project                     = "zeet-demo"
      + version                     = (known after apply)

      + autoscaling {
          + max_node_count = 20
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + node_config {
          + disk_size_gb      = 200
          + disk_type         = "pd-standard"
          + guest_accelerator = [
              + {
                  + count = 1
                  + type  = "nvidia-tesla-v100"
                },
            ]
          + image_type        = "COS_CONTAINERD"
          + labels            = {
              + "ZeetClusterId"                    = "zeet-zeet-example-gcp"
              + "ZeetUserId"                       = "random"
              + "cloud.google.com/gke-accelerator" = "nvidia-tesla-v100"
              + "cluster_name"                     = "zeet-zeet-zeet-example-gcp"
              + "node_pool"                        = "n1-standard-4-nvidia-v100"
              + "zeet.co/dedicated"                = "dedicated"
            }
          + local_ssd_count   = 0
          + machine_type      = "n1-standard-4"
          + metadata          = {
              + "ZeetClusterId"            = "zeet-zeet-example-gcp"
              + "ZeetUserId"               = "random"
              + "cluster_name"             = "zeet-zeet-zeet-example-gcp"
              + "disable-legacy-endpoints" = "true"
              + "node_pool"                = "n1-standard-4-nvidia-v100"
            }
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
              + "https://www.googleapis.com/auth/logging.write",
              + "https://www.googleapis.com/auth/monitoring",
            ]
          + preemptible       = false
          + service_account   = (known after apply)
          + spot              = false
          + tags              = [
              + "gke-zeet-zeet-zeet-example-gcp",
              + "gke-zeet-zeet-zeet-example-gcp-n1-standard-4-nvidia-v100",
            ]
          + taint             = (known after apply)

          + shielded_instance_config {
              + enable_integrity_monitoring = true
              + enable_secure_boot          = false
            }

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }

      + timeouts {
          + create = "45m"
          + delete = "45m"
          + update = "45m"
        }

      + upgrade_settings {
          + max_surge       = 1
          + max_unavailable = 0
        }
    }

  # module.gke.google_container_node_pool.pools["n1-standard-8-nvidia-k80"] will be created
  + resource "google_container_node_pool" "pools" {
      + cluster                     = "zeet-zeet-zeet-example-gcp"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "n1-standard-8-nvidia-k80"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = [
          + "us-west1-b",
        ]
      + operation                   = (known after apply)
      + project                     = "zeet-demo"
      + version                     = (known after apply)

      + autoscaling {
          + max_node_count = 20
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + node_config {
          + disk_size_gb      = 200
          + disk_type         = "pd-standard"
          + guest_accelerator = [
              + {
                  + count = 1
                  + type  = "nvidia-tesla-k80"
                },
            ]
          + image_type        = "COS_CONTAINERD"
          + labels            = {
              + "ZeetClusterId"                    = "zeet-zeet-example-gcp"
              + "ZeetUserId"                       = "random"
              + "cloud.google.com/gke-accelerator" = "nvidia-tesla-k80"
              + "cluster_name"                     = "zeet-zeet-zeet-example-gcp"
              + "node_pool"                        = "n1-standard-8-nvidia-k80"
              + "zeet.co/dedicated"                = "dedicated"
            }
          + local_ssd_count   = 0
          + machine_type      = "n1-standard-8"
          + metadata          = {
              + "ZeetClusterId"            = "zeet-zeet-example-gcp"
              + "ZeetUserId"               = "random"
              + "cluster_name"             = "zeet-zeet-zeet-example-gcp"
              + "disable-legacy-endpoints" = "true"
              + "node_pool"                = "n1-standard-8-nvidia-k80"
            }
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
              + "https://www.googleapis.com/auth/logging.write",
              + "https://www.googleapis.com/auth/monitoring",
            ]
          + preemptible       = false
          + service_account   = (known after apply)
          + spot              = false
          + tags              = [
              + "gke-zeet-zeet-zeet-example-gcp",
              + "gke-zeet-zeet-zeet-example-gcp-n1-standard-8-nvidia-k80",
            ]
          + taint             = (known after apply)

          + shielded_instance_config {
              + enable_integrity_monitoring = true
              + enable_secure_boot          = false
            }

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }

      + timeouts {
          + create = "45m"
          + delete = "45m"
          + update = "45m"
        }

      + upgrade_settings {
          + max_surge       = 1
          + max_unavailable = 0
        }
    }

  # module.gke.google_container_node_pool.pools["n1-standard-8-nvidia-p100"] will be created
  + resource "google_container_node_pool" "pools" {
      + cluster                     = "zeet-zeet-zeet-example-gcp"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "n1-standard-8-nvidia-p100"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = [
          + "us-west1-b",
        ]
      + operation                   = (known after apply)
      + project                     = "zeet-demo"
      + version                     = (known after apply)

      + autoscaling {
          + max_node_count = 20
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + node_config {
          + disk_size_gb      = 200
          + disk_type         = "pd-standard"
          + guest_accelerator = [
              + {
                  + count = 1
                  + type  = "nvidia-tesla-p100"
                },
            ]
          + image_type        = "COS_CONTAINERD"
          + labels            = {
              + "ZeetClusterId"                    = "zeet-zeet-example-gcp"
              + "ZeetUserId"                       = "random"
              + "cloud.google.com/gke-accelerator" = "nvidia-tesla-p100"
              + "cluster_name"                     = "zeet-zeet-zeet-example-gcp"
              + "node_pool"                        = "n1-standard-8-nvidia-p100"
              + "zeet.co/dedicated"                = "dedicated"
            }
          + local_ssd_count   = 0
          + machine_type      = "n1-standard-8"
          + metadata          = {
              + "ZeetClusterId"            = "zeet-zeet-example-gcp"
              + "ZeetUserId"               = "random"
              + "cluster_name"             = "zeet-zeet-zeet-example-gcp"
              + "disable-legacy-endpoints" = "true"
              + "node_pool"                = "n1-standard-8-nvidia-p100"
            }
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
              + "https://www.googleapis.com/auth/logging.write",
              + "https://www.googleapis.com/auth/monitoring",
            ]
          + preemptible       = false
          + service_account   = (known after apply)
          + spot              = false
          + tags              = [
              + "gke-zeet-zeet-zeet-example-gcp",
              + "gke-zeet-zeet-zeet-example-gcp-n1-standard-8-nvidia-p100",
            ]
          + taint             = (known after apply)

          + shielded_instance_config {
              + enable_integrity_monitoring = true
              + enable_secure_boot          = false
            }

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }

      + timeouts {
          + create = "45m"
          + delete = "45m"
          + update = "45m"
        }

      + upgrade_settings {
          + max_surge       = 1
          + max_unavailable = 0
        }
    }

  # module.gke.google_container_node_pool.pools["n1-standard-8-nvidia-t4"] will be created
  + resource "google_container_node_pool" "pools" {
      + cluster                     = "zeet-zeet-zeet-example-gcp"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "n1-standard-8-nvidia-t4"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = [
          + "us-west1-b",
        ]
      + operation                   = (known after apply)
      + project                     = "zeet-demo"
      + version                     = (known after apply)

      + autoscaling {
          + max_node_count = 20
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + node_config {
          + disk_size_gb      = 200
          + disk_type         = "pd-standard"
          + guest_accelerator = [
              + {
                  + count = 1
                  + type  = "nvidia-tesla-t4"
                },
            ]
          + image_type        = "COS_CONTAINERD"
          + labels            = {
              + "ZeetClusterId"                    = "zeet-zeet-example-gcp"
              + "ZeetUserId"                       = "random"
              + "cloud.google.com/gke-accelerator" = "nvidia-tesla-t4"
              + "cluster_name"                     = "zeet-zeet-zeet-example-gcp"
              + "node_pool"                        = "n1-standard-8-nvidia-t4"
              + "zeet.co/dedicated"                = "dedicated"
            }
          + local_ssd_count   = 0
          + machine_type      = "n1-standard-8"
          + metadata          = {
              + "ZeetClusterId"            = "zeet-zeet-example-gcp"
              + "ZeetUserId"               = "random"
              + "cluster_name"             = "zeet-zeet-zeet-example-gcp"
              + "disable-legacy-endpoints" = "true"
              + "node_pool"                = "n1-standard-8-nvidia-t4"
            }
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
              + "https://www.googleapis.com/auth/logging.write",
              + "https://www.googleapis.com/auth/monitoring",
            ]
          + preemptible       = false
          + service_account   = (known after apply)
          + spot              = false
          + tags              = [
              + "gke-zeet-zeet-zeet-example-gcp",
              + "gke-zeet-zeet-zeet-example-gcp-n1-standard-8-nvidia-t4",
            ]
          + taint             = (known after apply)

          + shielded_instance_config {
              + enable_integrity_monitoring = true
              + enable_secure_boot          = false
            }

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }

      + timeouts {
          + create = "45m"
          + delete = "45m"
          + update = "45m"
        }

      + upgrade_settings {
          + max_surge       = 1
          + max_unavailable = 0
        }
    }

  # module.gke.google_container_node_pool.pools["n1-standard-8-nvidia-v100"] will be created
  + resource "google_container_node_pool" "pools" {
      + cluster                     = "zeet-zeet-zeet-example-gcp"
      + id                          = (known after apply)
      + initial_node_count          = 0
      + instance_group_urls         = (known after apply)
      + location                    = "us-west1-b"
      + managed_instance_group_urls = (known after apply)
      + max_pods_per_node           = (known after apply)
      + name                        = "n1-standard-8-nvidia-v100"
      + name_prefix                 = (known after apply)
      + node_count                  = (known after apply)
      + node_locations              = [
          + "us-west1-b",
        ]
      + operation                   = (known after apply)
      + project                     = "zeet-demo"
      + version                     = (known after apply)

      + autoscaling {
          + max_node_count = 20
          + min_node_count = 0
        }

      + management {
          + auto_repair  = true
          + auto_upgrade = true
        }

      + node_config {
          + disk_size_gb      = 200
          + disk_type         = "pd-standard"
          + guest_accelerator = [
              + {
                  + count = 1
                  + type  = "nvidia-tesla-v100"
                },
            ]
          + image_type        = "COS_CONTAINERD"
          + labels            = {
              + "ZeetClusterId"                    = "zeet-zeet-example-gcp"
              + "ZeetUserId"                       = "random"
              + "cloud.google.com/gke-accelerator" = "nvidia-tesla-v100"
              + "cluster_name"                     = "zeet-zeet-zeet-example-gcp"
              + "node_pool"                        = "n1-standard-8-nvidia-v100"
              + "zeet.co/dedicated"                = "dedicated"
            }
          + local_ssd_count   = 0
          + machine_type      = "n1-standard-8"
          + metadata          = {
              + "ZeetClusterId"            = "zeet-zeet-example-gcp"
              + "ZeetUserId"               = "random"
              + "cluster_name"             = "zeet-zeet-zeet-example-gcp"
              + "disable-legacy-endpoints" = "true"
              + "node_pool"                = "n1-standard-8-nvidia-v100"
            }
          + oauth_scopes      = [
              + "https://www.googleapis.com/auth/cloud-platform",
              + "https://www.googleapis.com/auth/logging.write",
              + "https://www.googleapis.com/auth/monitoring",
            ]
          + preemptible       = false
          + service_account   = (known after apply)
          + spot              = false
          + tags              = [
              + "gke-zeet-zeet-zeet-example-gcp",
              + "gke-zeet-zeet-zeet-example-gcp-n1-standard-8-nvidia-v100",
            ]
          + taint             = (known after apply)

          + shielded_instance_config {
              + enable_integrity_monitoring = true
              + enable_secure_boot          = false
            }

          + workload_metadata_config {
              + mode = "GKE_METADATA"
            }
        }

      + timeouts {
          + create = "45m"
          + delete = "45m"
          + update = "45m"
        }

      + upgrade_settings {
          + max_surge       = 1
          + max_unavailable = 0
        }
    }

…
```